### PR TITLE
Fix quoting of arguments with special characters

### DIFF
--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -158,7 +158,12 @@ _print_path() {
 # Execute a command with expanded args, e.g. Delete files 6 to 12: $ ge rm 6-12
 # Fails if command is a number or range (probably not worth fixing)
 exec_scmb_expand_args() {
-  eval "$(scmb_expand_args "$@" | sed -e "s/\([][()<>^ \"']\)/"'\\\1/g')"
+  local expanded=( $(scmb_expand_args "$@") )
+  local quoted=()
+  for word in "${expanded[@]}"; do
+    quoted=( "${quoted[@]}" "$(printf "%q" "$word")" )
+  done
+  eval "${quoted[@]}"
 }
 
 # Clear numbered env variables


### PR DESCRIPTION
If you had a file with a character that had a special meaning in a shell
command line, scmb_expand_args would not requote the string before it
was run through eval.

Here is a an example problem:

touch 'foo;bar'
rm 'foo;bar'

This would try to run "rm foo;bar" and get an error that "foo" doesn't
exist and "bar" is an invalid command.