### PR TITLE
Fix argument expansion in __git_alias

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -64,11 +64,11 @@ _git
 # Usage: __git_alias <alias> <command_prefix> <command>
 __git_alias () {
   if [ -n "$1" ]; then
-    local alias_str="$1"; local cmd_prefix="$2"; local cmd="$3"; local cmd_args="${4-}"
-    alias $alias_str="$cmd_prefix $cmd${cmd_args:+ }$cmd_args"
+    local alias_str="$1"; local cmd_prefix="$2"; local cmd="$3"; local cmd_args=("${@:4}")
+    alias $alias_str="$cmd_prefix $cmd${cmd_args:+ }${cmd_args[*]}"
     if [ "$shell" = "bash" ]; then
-      __define_git_completion $alias_str $cmd
-      complete -o default -o nospace -F _git_"$alias_str"_shortcut $alias_str
+      __define_git_completion "$alias_str" "$cmd"
+      complete -o default -o nospace -F _git_"$alias_str"_shortcut "$alias_str"
     fi
   fi
 }


### PR DESCRIPTION
Without this fix, all subcommands or options after the 2nd are truncated.