### PR TITLE
Make ls aliases optional

### DIFF
--- a/git.scmbrc.example
+++ b/git.scmbrc.example
@@ -114,3 +114,5 @@ git_commit_all_with_ci_skip_keys="\C-xv"  # CTRL+x, v    (Appends [ci skip] to c
 shell_command_wrapping_enabled="true"
 # Here you can tweak the list of wrapped commands.
 scmb_wrapped_shell_commands="vim emacs gedit cat rm cp mv ln cd"
+# Add numbered shortcuts to output of ls -l, just like 'git status'
+shell_ls_aliases_enabled="true"

--- a/lib/git/shell_shortcuts.sh
+++ b/lib/git/shell_shortcuts.sh
@@ -108,50 +108,51 @@ fi
 
 # Function wrapper around 'll'
 # Adds numbered shortcuts to output of ls -l, just like 'git status'
-unalias ll > /dev/null 2>&1; unset -f ll > /dev/null 2>&1
-function ls_with_file_shortcuts {
-  local ll_output
-  if [ "$_ls_bsd" != "BSD" ]; then
-  	ll_output="$(\ls -lhv --group-directories-first --color "$@")"
-  else
-    ll_output="$(CLICOLOR_FORCE=1 \ls -l -G "$@")"
-  fi
+if [ "$shell_ls_aliases_enabled" = "true" ]; then
+  unalias ll > /dev/null 2>&1; unset -f ll > /dev/null 2>&1
+  function ls_with_file_shortcuts {
+    local ll_output
+    if [ "$_ls_bsd" != "BSD" ]; then
+      ll_output="$(\ls -lhv --group-directories-first --color "$@")"
+    else
+      ll_output="$(CLICOLOR_FORCE=1 \ls -l -G "$@")"
+    fi
 
-  if [[ $shell == "zsh" ]]; then
-    # Ensure sh_word_split is on
-    if setopt | grep -q shwordsplit; then SHWORDSPLIT_ON=true; fi
-    setopt shwordsplit
-  fi
+    if [[ $shell == "zsh" ]]; then
+      # Ensure sh_word_split is on
+      if setopt | grep -q shwordsplit; then SHWORDSPLIT_ON=true; fi
+      setopt shwordsplit
+    fi
 
-  # Parse path from args
-  OLDIFS="$IFS"; IFS=$'\n'
-  for arg in $@; do
-    if [ -d "$arg" ]; then local rel_path="${arg%/}"; fi
-  done
-  IFS="$OLDIFS"
+    # Parse path from args
+    OLDIFS="$IFS"; IFS=$'\n'
+    for arg in $@; do
+      if [ -d "$arg" ]; then local rel_path="${arg%/}"; fi
+    done
+    IFS="$OLDIFS"
 
-  # Replace user/group with user symbol, if defined at ~/.user_sym
-  # Before : -rw-rw-r-- 1 ndbroadbent ndbroadbent 1.1K Sep 19 21:39 scm_breeze.sh
-  # After  : -rw-rw-r-- 1 𝐍  𝐍  1.1K Sep 19 21:39 scm_breeze.sh
-  if [ -e $HOME/.user_sym ]; then
-    # Little bit of ruby golf to rejustify the user/group/size columns after replacement
-    function rejustify_ls_columns(){
-      ruby -e "o=STDIN.read;re=/^(([^ ]* +){2})(([^ ]* +){3})/;\
-               u,g,s=o.lines.map{|l|l[re,3]}.compact.map(&:split).transpose.map{|a|a.map(&:size).max+1};\
-               puts o.lines.map{|l|l.sub(re){|m|\"%s%-#{u}s %-#{g}s%#{s}s \"%[\$1,*\$3.split]}}"
-    }
+    # Replace user/group with user symbol, if defined at ~/.user_sym
+    # Before : -rw-rw-r-- 1 ndbroadbent ndbroadbent 1.1K Sep 19 21:39 scm_breeze.sh
+    # After  : -rw-rw-r-- 1 𝐍  𝐍  1.1K Sep 19 21:39 scm_breeze.sh
+    if [ -e $HOME/.user_sym ]; then
+      # Little bit of ruby golf to rejustify the user/group/size columns after replacement
+      function rejustify_ls_columns(){
+        ruby -e "o=STDIN.read;re=/^(([^ ]* +){2})(([^ ]* +){3})/;\
+                 u,g,s=o.lines.map{|l|l[re,3]}.compact.map(&:split).transpose.map{|a|a.map(&:size).max+1};\
+                 puts o.lines.map{|l|l.sub(re){|m|\"%s%-#{u}s %-#{g}s%#{s}s \"%[\$1,*\$3.split]}}"
+      }
 
-    ll_output=$(echo "$ll_output" | \sed -$SED_REGEX_ARG "s/ $USER/ $(/bin/cat $HOME/.user_sym)/g" | rejustify_ls_columns)
-  fi
+      ll_output=$(echo "$ll_output" | \sed -$SED_REGEX_ARG "s/ $USER/ $(/bin/cat $HOME/.user_sym)/g" | rejustify_ls_columns)
+    fi
 
-  if [ "$(echo "$ll_output" | wc -l)" -gt "50" ]; then
-    echo -e "\033[33mToo many files to create shortcuts. Running plain ll command...\033[0m"
-    echo "$ll_output"
-    return 1
-  fi
+    if [ "$(echo "$ll_output" | wc -l)" -gt "50" ]; then
+      echo -e "\033[33mToo many files to create shortcuts. Running plain ll command...\033[0m"
+      echo "$ll_output"
+      return 1
+    fi
 
-  # Use ruby to inject numbers into ls output
-  echo "$ll_output" | ruby -e "$( \cat <<EOF
+    # Use ruby to inject numbers into ls output
+    echo "$ll_output" | ruby -e "$( \cat <<EOF
 output = STDIN.read
 e = 1
 re = /^(([^ ]* +){8})/
@@ -163,30 +164,31 @@ end
 EOF
 )"
 
-  # Set numbered file shortcut in variable
-  local e=1
-  local ll_files=''
-  local file=''
+    # Set numbered file shortcut in variable
+    local e=1
+    local ll_files=''
+    local file=''
 
-  if [ -z $_ls_bsd ]; then
-    ll_files="$(\ls -v --group-directories-first --color=never "$@")"
-  else
-    ll_files="$(\ls "$@")"
-  fi
+    if [ -z $_ls_bsd ]; then
+      ll_files="$(\ls -v --group-directories-first --color=never "$@")"
+    else
+      ll_files="$(\ls "$@")"
+    fi
 
-  OLDIFS="$IFS"; IFS=$'\n'
-  for file in $ll_files; do
-    if [ -n "$rel_path" ]; then file="$rel_path/$file"; fi
-    export $git_env_char$e="$(eval $_abs_path_command \"${file//\"/\\\"}\")"
-    if [ "${scmbDebug:-}" = "true" ]; then echo "Set \$$git_env_char$e  => $file"; fi
-    let e++
-  done
-  IFS="$OLDIFS"
+    OLDIFS="$IFS"; IFS=$'\n'
+    for file in $ll_files; do
+      if [ -n "$rel_path" ]; then file="$rel_path/$file"; fi
+      export $git_env_char$e="$(eval $_abs_path_command \"${file//\"/\\\"}\")"
+      if [ "${scmbDebug:-}" = "true" ]; then echo "Set \$$git_env_char$e  => $file"; fi
+      let e++
+    done
+    IFS="$OLDIFS"
 
-  # Turn off shwordsplit unless it was on previously
-  if [[ $shell == "zsh" ]] && [ -z "$SHWORDSPLIT_ON" ]; then unsetopt shwordsplit; fi
-}
+    # Turn off shwordsplit unless it was on previously
+    if [[ $shell == "zsh" ]] && [ -z "$SHWORDSPLIT_ON" ]; then unsetopt shwordsplit; fi
+  }
 
-# Setup aliases
-alias ll="exec_scmb_expand_args ls_with_file_shortcuts"
-alias la="ll -A"
+  # Setup aliases
+  alias ll="exec_scmb_expand_args ls_with_file_shortcuts"
+  alias la="ll -A"
+fi

--- a/test/lib/git/shell_shortcuts_test.sh
+++ b/test/lib/git/shell_shortcuts_test.sh
@@ -26,6 +26,7 @@ source "$scmbDir/lib/scm_breeze.sh"
 oneTimeSetUp() {
   export shell_command_wrapping_enabled="true"
   export scmb_wrapped_shell_commands="not_found cat rm cp mv ln cd sed"
+  export shell_ls_aliases_enabled="true"
 
   alias rvm="test" # Ensure tests run if RVM isn't loaded but $HOME/.rvm is present
 


### PR DESCRIPTION
The `ls` aliases are nice, but can be pretty slow for big directories, depending on the hardware. And this is *SCM* Breeze, not *ls* Breeze
This makes them optional, with configuration variable `$shell_ls_aliases_enabled` (true by default).