### PR TITLE
Fix quoting of semicolon and pipe

### DIFF
--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -158,7 +158,7 @@ _print_path() {
 # Execute a command with expanded args, e.g. Delete files 6 to 12: $ ge rm 6-12
 # Fails if command is a number or range (probably not worth fixing)
 exec_scmb_expand_args() {
-  eval "$(scmb_expand_args "$@" | sed -e "s/\([][()<>^ \"']\)/"'\\\1/g')"
+  eval "$(scmb_expand_args "$@" | sed -e "s/\([][|;()<>^ \"']\)/"'\\\1/g')"
 }
 
 # Clear numbered env variables

--- a/test/lib/git/status_shortcuts_test.sh
+++ b/test/lib/git/status_shortcuts_test.sh
@@ -60,6 +60,10 @@ test_scmb_expand_args() {
                         "$(scmb_expand_args -ma "Test Commit Message" "Unquoted")"
 }
 
+test_command_wrapping_escapes_special_characters() {
+    assertEquals 'should escape | the pipe' "$(exec_scmb_expand_args echo "should escape | the pipe")"
+    assertEquals 'should escape ; the semicolon' "$(exec_scmb_expand_args echo "should escape ; the semicolon")"
+}
 
 test_git_status_shortcuts() {
   setupTestRepo
@@ -252,10 +256,10 @@ test_git_commit_prompt() {
   assertIncludes "$git_show_output"  "$commit_msg"
 
   # Test that history was appended correctly.
-  if [[ $shell == "zsh" ]]; then 
-    test_history="$(history)"    
+  if [[ $shell == "zsh" ]]; then
+    test_history="$(history)"
   else
-    test_history="$(cat $HISTFILE)"    
+    test_history="$(cat $HISTFILE)"
   fi
   assertIncludes "$test_history"  "$commit_msg"
   assertIncludes "$test_history"  "git commit -m \"$dbl_escaped_msg\""
@@ -285,10 +289,10 @@ test_git_commit_prompt_with_append() {
   assertIncludes "$git_show_output"  "$commit_msg \[ci skip\]"
 
   # Test that history was appended correctly.
-  if [[ $shell == "zsh" ]]; then 
-    test_history="$(history)"    
+  if [[ $shell == "zsh" ]]; then
+    test_history="$(history)"
   else
-    test_history="$(cat $HISTFILE)"    
+    test_history="$(cat $HISTFILE)"
   fi
   assertIncludes "$test_history"  "$commit_msg \[ci skip\]"
   assertIncludes "$test_history"  "git commit -m \"$commit_msg \[ci skip\]\""
@@ -312,4 +316,3 @@ test_adding_files_with_spaces() {
 
 # load and run shUnit2
 source "$scmbDir/test/support/shunit2"
-


### PR DESCRIPTION
Adds these two special characters to be quoted properly before eval. With unit test.