### PR TITLE
Offset starts from 0 so the argument would be 3

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -65,7 +65,7 @@ _git
 __git_alias () {
   if [ -n "$1" ]; then
     local alias_str cmd_prefix cmd cmd_args
-    alias_str="$1"; cmd_prefix="$2"; cmd="$3"; cmd_args=("${@:4}")
+    alias_str="$1"; cmd_prefix="$2"; cmd="$3"; cmd_args=("${@:3}")
     alias $alias_str="$cmd_prefix $cmd${cmd_args:+ }${cmd_args[*]}"
     if [ "$shell" = "bash" ]; then
       __define_git_completion "$alias_str" "$cmd"


### PR DESCRIPTION
This patch fixes broken aliases which have arguments (e.g. gap)