### PR TITLE
Fix setting alias for "_scmb_git_branch_shortcuts"

### DIFF
--- a/lib/git/branch_shortcuts.sh
+++ b/lib/git/branch_shortcuts.sh
@@ -39,7 +39,7 @@ EOF
   done
 }
 
-__git_alias "$git_branch_alias"              "_scmb_git_branch_shortcuts"
+__git_alias "$git_branch_alias"              "_scmb_git_branch_shortcuts" ""
 __git_alias "$git_branch_all_alias"          "_scmb_git_branch_shortcuts" "-a"
 __git_alias "$git_branch_move_alias"         "_scmb_git_branch_shortcuts" "-m"
 __git_alias "$git_branch_delete_alias"       "_scmb_git_branch_shortcuts" "-d"


### PR DESCRIPTION
__git_alias expects three arguments. Passing two arguments to __git_alias for "gb" leads to undesirable behaviour on some platforms.