### PR TITLE
exec_scmb_expand_args: Escape ampersands.

### DIFF
--- a/lib/git/status_shortcuts.sh
+++ b/lib/git/status_shortcuts.sh
@@ -158,7 +158,7 @@ _print_path() {
 # Execute a command with expanded args, e.g. Delete files 6 to 12: $ ge rm 6-12
 # Fails if command is a number or range (probably not worth fixing)
 exec_scmb_expand_args() {
-  eval "$(scmb_expand_args "$@" | sed -e "s/\([][|;()<>^ \"']\)/"'\\\1/g')"
+  eval "$(scmb_expand_args "$@" | sed -e "s/\([][|;()<>^ \"'&]\)/"'\\\1/g')"
 }
 
 # Clear numbered env variables


### PR DESCRIPTION
Fixes this bug:

```
$ touch abc\&xyz
$ rm *xyz
[3] 16234
rm: abc: No such file or directory
[3]  + 16234 exit 1     /bin/rm abc
(eval):1: command not found: xyz
```