### PR TITLE
Use >| operator in _rebuild_git_index when overwriting .git_index file

### DIFF
--- a/lib/git/repo_index.sh
+++ b/lib/git/repo_index.sh
@@ -149,7 +149,7 @@ function _rebuild_git_index() {
   IFS=$'\n'
   for repo in $(echo -e "$(_find_git_repos)\n$(echo $GIT_REPOS | sed "s/:/\\\\n/g")"); do
     echo $(basename $repo | sed "s/ /_/g") $repo
-  done | sort | cut -d " " -f2- > "$GIT_REPO_DIR/.git_index"
+  done | sort | cut -d " " -f2- >| "$GIT_REPO_DIR/.git_index"
   IFS=$' \t\n'
 
   if [ "$1" != "--silent" ]; then


### PR DESCRIPTION
If the shell has the noclobber option set, s --rebuild will fail to
update the .git_index file. Using the >| operator instead of the >
operator forces the .git_index file to be clobbered, which is the
desired behavior.