### PR TITLE
Fix infinite loop in shell with babun (cygwin)

### DIFF
--- a/lib/git/fallback/status_shortcuts_shell.sh
+++ b/lib/git/fallback/status_shortcuts_shell.sh
@@ -127,7 +127,7 @@ _gs_output_file_group() {
     if [ -z "$project_root" ]; then
       relative="${stat_file[$i]}"
     else
-      dest="$project_root/${stat_file[$i]}"
+      dest=$(readlink -f "$project_root/${stat_file[$i]}")
       local pwd=$(readlink -f "$PWD")
       relative="$(_gs_relative_path "$pwd" "$dest" )"
     fi


### PR DESCRIPTION
Resolve symlinks to match `pwd`, so that `_gs_relative_path` does not loop forever.