### PR TITLE
Swapping the commands check

### DIFF
--- a/lib/git/aliases.sh
+++ b/lib/git/aliases.sh
@@ -19,8 +19,8 @@ unset -f git > /dev/null 2>&1
 # Use the full path to git to avoid infinite loop with git function
 export _git_cmd="$(\which git)"
 # Wrap git with the 'hub' github wrapper, if installed (https://github.com/defunkt/hub)
-if type hub > /dev/null 2>&1; then export _git_cmd="hub"; fi
 if type gh  > /dev/null 2>&1; then export _git_cmd="gh"; fi
+if type hub > /dev/null 2>&1; then export _git_cmd="hub"; fi
 
 # Create 'git' function that calls hub if defined, and expands all numeric arguments
 function git(){


### PR DESCRIPTION
This commit swaps the two exports of the commands "hub" and "gh" in the
aliases. The fact is the export of "gh" overwrites the previous one, and
the official GitHub client is using "hub" as command.

See https://github.com/github/hub/issues/475.
Closes #209